### PR TITLE
fr[9] - make rails_helper required in RSpec instead of spec_helper

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---require spec_helper
+--require rails_helper


### PR DESCRIPTION
fr[9] - make rails_helper required in RSpec instead of spec_helper